### PR TITLE
Less state, less duplicated code in SWCoreWindowService

### DIFF
--- a/Switch/SWCoreWindowService.m
+++ b/Switch/SWCoreWindowService.m
@@ -402,7 +402,7 @@ static int kScrollThreshold = 50;
     @weakify(self);
     SWEventTap *eventTap = [SWEventTap sharedService];
 
-    BOOL (^selectorChange)(CGEventRef, BOOL, BOOL) = ^(CGEventRef event, BOOL invokesInterface, BOOL incrementing) {
+    BOOL (^updateSelector)(CGEventRef, BOOL, BOOL) = ^(CGEventRef event, BOOL invokesInterface, BOOL incrementing) {
         BailUnless(event, YES);
         
         // If this hotKey doesn't invoke the interface and it is not already active, pass the event through and do nothing.
@@ -443,25 +443,25 @@ static int kScrollThreshold = 50;
     // Incrementing/invoking is bound to option-tab by default.
     [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_Tab modifiers:SWHotKeyModifierOption] object:self block:^BOOL(CGEventRef event) {
         // Invokes, incrementing.
-        return selectorChange(event, YES, YES);
+        return updateSelector(event, YES, YES);
     }];
 
     // Option-arrow can be used to change the selection when Switch has been invoked.
     [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_RightArrow modifiers:SWHotKeyModifierOption] object:self block:^BOOL(CGEventRef event) {
         // Does not invoke, incrementing.
-        return selectorChange(event, NO, YES);
+        return updateSelector(event, NO, YES);
     }];
 
     // Decrementing/invoking is bound to option-shift-tab by default.
     [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_Tab modifiers:(SWHotKeyModifierOption|SWHotKeyModifierShift)] object:self block:^BOOL(CGEventRef event) {
         // Invokes, decrementing.
-        return selectorChange(event, YES, NO);
+        return updateSelector(event, YES, NO);
     }];
 
     // Option-arrow can be used to change the selection when Switch has been invoked.
     [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_LeftArrow modifiers:SWHotKeyModifierOption] object:self block:^BOOL(CGEventRef event) {
         // Does not invoke, decrementing.
-        return selectorChange(event, NO, NO);
+        return updateSelector(event, NO, NO);
     }];
 
     // Closing a window is bound to option-W when the interface is open.

--- a/Switch/SWCoreWindowService.m
+++ b/Switch/SWCoreWindowService.m
@@ -44,8 +44,6 @@ static int kScrollThreshold = 50;
 #pragma mark Selector state
 @property (nonatomic, strong) SWSelector *selector;
 @property (nonatomic, assign) int scrollOffset;
-@property (nonatomic, assign) BOOL incrementing;
-@property (nonatomic, assign) BOOL decrementing;
 
 #pragma mark Logging state
 @property (nonatomic, strong) NSDate *invocationTime;
@@ -404,79 +402,71 @@ static int kScrollThreshold = 50;
     @weakify(self);
     SWEventTap *eventTap = [SWEventTap sharedService];
 
-    void (^selectorChange)(BOOL, BOOL, BOOL) = ^(BOOL keyDown, BOOL invokesInterface, BOOL incrementing) {
-        @strongify(self);
+    BOOL (^selectorChange)(CGEventRef, BOOL, BOOL) = ^(CGEventRef event, BOOL invokesInterface, BOOL incrementing) {
+        BailUnless(event, YES);
         
-        if (keyDown) {
-            if (invokesInterface) {
-                self.invoked = YES;
-            }
-            
-            if (incrementing ? self.incrementing : self.decrementing) {
-                self.selector = incrementing ? self.selector.incrementWithoutWrapping : self.selector.decrementWithoutWrapping;
-            } else {
-                self.selector = incrementing ? self.selector.increment : self.selector.decrement;
-            }
-            
-            self.scrollOffset = 0;
+        // If this hotKey doesn't invoke the interface and it is not already active, pass the event through and do nothing.
+        if (!invokesInterface && !self.invoked) {
+            return YES;
         }
         
-        // I wish I could just use (incrementing ? self.incrementing : self.decrementing) = keyDown
-        if (incrementing) {
-            self.incrementing = keyDown;
-        } else {
-            self.decrementing = keyDown;
-        }
+        // The event is passed by reference. Copy it in case it mutates after control returns to the caller.
+        event = CGEventCreateCopy(event);
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            @strongify(self);
+            
+            if (CGEventGetType(event) == kCGEventKeyDown) {
+                if (invokesInterface) {
+                    self.invoked = YES;
+                }
+
+                if (!Check(self.invoked)) {
+                    return;
+                }
+
+                if (CGEventGetIntegerValueField(event, kCGKeyboardEventAutorepeat)) {
+                    self.selector = incrementing ? self.selector.incrementWithoutWrapping : self.selector.decrementWithoutWrapping;
+                } else {
+                    self.selector = incrementing ? self.selector.increment : self.selector.decrement;
+                }
+                
+                self.scrollOffset = 0;
+            }
+            CFRelease(event);
+        });
+        
+        return NO;
     };
     
     // Incrementing/invoking is bound to option-tab by default.
-    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_Tab modifiers:SWHotKeyModifierOption] object:self block:^BOOL(BOOL keyDown) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            // Invokes, incrementing.
-            selectorChange(keyDown, YES, YES);
-        });
-        return NO;
+    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_Tab modifiers:SWHotKeyModifierOption] object:self block:^BOOL(CGEventRef event) {
+        // Invokes, incrementing.
+        return selectorChange(event, YES, YES);
     }];
 
     // Option-arrow can be used to change the selection when Switch has been invoked.
-    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_RightArrow modifiers:SWHotKeyModifierOption] object:self block:^BOOL(BOOL keyDown) {
-        @strongify(self);
-        if (self.invoked) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                // Does not invoke, incrementing.
-                selectorChange(keyDown, NO, YES);
-            });
-            return NO;
-        }
-        return YES;
+    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_RightArrow modifiers:SWHotKeyModifierOption] object:self block:^BOOL(CGEventRef event) {
+        // Does not invoke, incrementing.
+        return selectorChange(event, NO, YES);
     }];
 
     // Decrementing/invoking is bound to option-shift-tab by default.
-    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_Tab modifiers:(SWHotKeyModifierOption|SWHotKeyModifierShift)] object:self block:^BOOL(BOOL keyDown) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            // Invokes, decrementing.
-            selectorChange(keyDown, YES, NO);
-        });
-        return NO;
+    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_Tab modifiers:(SWHotKeyModifierOption|SWHotKeyModifierShift)] object:self block:^BOOL(CGEventRef event) {
+        // Invokes, decrementing.
+        return selectorChange(event, YES, NO);
     }];
 
     // Option-arrow can be used to change the selection when Switch has been invoked.
-    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_LeftArrow modifiers:SWHotKeyModifierOption] object:self block:^BOOL(BOOL keyDown) {
-        @strongify(self);
-        if (self.invoked) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                // Does not invoke, decrementing.
-                selectorChange(keyDown, NO, NO);
-            });
-            return NO;
-        }
-        return YES;
+    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_LeftArrow modifiers:SWHotKeyModifierOption] object:self block:^BOOL(CGEventRef event) {
+        // Does not invoke, decrementing.
+        return selectorChange(event, NO, NO);
     }];
 
     // Closing a window is bound to option-W when the interface is open.
-    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_ANSI_W modifiers:SWHotKeyModifierOption] object:self block:^BOOL(BOOL keyDown) {
+    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_ANSI_W modifiers:SWHotKeyModifierOption] object:self block:^BOOL(CGEventRef event) {
         @strongify(self);
-        if (keyDown && self.interfaceVisible) {
+        if (CGEventGetType(event) == kCGEventKeyDown && self.interfaceVisible) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 @strongify(self);
                 [self _closeSelectedWindow];
@@ -487,8 +477,9 @@ static int kScrollThreshold = 50;
     }];
 
     // Showing the preferences is bound to option-, when the interface is open. This action closes the interface.
-    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_ANSI_Comma modifiers:SWHotKeyModifierOption] object:self block:^BOOL(BOOL keyDown) {
-        if (keyDown && self.interfaceVisible) {
+    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_ANSI_Comma modifiers:SWHotKeyModifierOption] object:self block:^BOOL(CGEventRef event) {
+        @strongify(self);
+        if (CGEventGetType(event) == kCGEventKeyDown && self.invoked) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 @strongify(self);
                 self.invoked = NO;
@@ -500,9 +491,9 @@ static int kScrollThreshold = 50;
     }];
 
     // Cancelling the switcher is bound to option-escape. This action closes the interface.
-    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_Escape modifiers:SWHotKeyModifierOption] object:self block:^(BOOL keyDown){
+    [eventTap registerHotKey:[SWHotKey hotKeyWithKeycode:kVK_Escape modifiers:SWHotKeyModifierOption] object:self block:^(CGEventRef event){
         @strongify(self);
-        if (keyDown && self.invoked) {
+        if (CGEventGetType(event) == kCGEventKeyDown && self.invoked) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 self.invoked = NO;
             });

--- a/Switch/SWCoreWindowService.m
+++ b/Switch/SWCoreWindowService.m
@@ -410,11 +410,13 @@ static int kScrollThreshold = 50;
             return YES;
         }
         
-        // The event is passed by reference. Copy it in case it mutates after control returns to the caller.
+        // The event is passed by reference. Copy it in case it mutates after control returns to the caller. Released in the async block below.
         event = CGEventCreateCopy(event);
-
         dispatch_async(dispatch_get_main_queue(), ^{
             @strongify(self);
+
+            // Avoid leaking the event if this block early-returns.
+            NNCFAutorelease(event);
             
             if (CGEventGetType(event) == kCGEventKeyDown) {
                 if (invokesInterface) {
@@ -433,7 +435,6 @@ static int kScrollThreshold = 50;
                 
                 self.scrollOffset = 0;
             }
-            CFRelease(event);
         });
         
         return NO;

--- a/Switch/SWEventTap.h
+++ b/Switch/SWEventTap.h
@@ -15,7 +15,7 @@
 #import "SWHotKey.h"
 
 
-typedef BOOL (^SWEventTapKeyFilter)(BOOL keyDown);
+typedef BOOL (^SWEventTapKeyFilter)(CGEventRef event);
 typedef void (^SWEventTapModifierCallback)(BOOL matched);
 typedef void (^SWEventTapCallback)(CGEventRef event);
 

--- a/Switch/SWEventTap.m
+++ b/Switch/SWEventTap.m
@@ -263,7 +263,7 @@ static CGEventRef eventCallback(CGEventTapProxy proxy, CGEventType type, CGEvent
     //
     
     for (SWEventTapKeyFilter filter in [eventTap.keyFilters[key] allValues]) {
-        if (!filter(type == kCGEventKeyDown)) {
+        if (!filter(event)) {
             event = NULL;
             break;
         }


### PR DESCRIPTION
Also fixes an errant retain on `self` in the block for `kVK_ANSI_Comma`.

Fixes #80.
