### PR TITLE
Encapsulate flippedness of CG window frames better.

### DIFF
--- a/Switch/NSScreen+SWAdditions.h
+++ b/Switch/NSScreen+SWAdditions.h
@@ -19,6 +19,4 @@
 
 + (CGFloat)sw_totalScreenHeight;
 
-- (CGRect)sw_absoluteFrame;
-
 @end

--- a/Switch/SWAccessibilityService.m
+++ b/Switch/SWAccessibilityService.m
@@ -250,7 +250,7 @@
         CGRect haxFrame = haxWindow.frame;
         haxFrame.origin.y = NSScreen.sw_totalScreenHeight - (haxFrame.origin.y + haxFrame.size.height);
         
-        BOOL framesMatch = NNNSRectsEqual(window.frame, haxFrame);
+        BOOL framesMatch = NNCGRectsEqual(window.frame, haxFrame);
         // AX will return an empty string when CG returns nil/unset!
         BOOL namesMatch = (window.name.length == 0 && haxTitle.length == 0) || [window.name isEqualToString:haxTitle];
         

--- a/Switch/SWAccessibilityService.m
+++ b/Switch/SWAccessibilityService.m
@@ -18,6 +18,7 @@
 #import <Haxcessibility/Haxcessibility.h>
 #import <Haxcessibility/HAXElement+Protected.h>
 
+#import "NSScreen+SWAdditions.h"
 #import "SWAPIEnabledWorker.h"
 #import "SWApplication.h"
 #import "SWWindow.h"
@@ -244,7 +245,12 @@
     
     return [[haxApplication windows] nn_reduce:^id(id accumulator, HAXWindow *haxWindow){
         NSString *haxTitle = haxWindow.title;
-        BOOL framesMatch = NNNSRectsEqual(window.frame, haxWindow.frame);
+        
+        // This should ultimately be flipped in Haxcessibility, per #89.
+        CGRect haxFrame = haxWindow.frame;
+        haxFrame.origin.y = NSScreen.sw_totalScreenHeight - (haxFrame.origin.y + haxFrame.size.height);
+        
+        BOOL framesMatch = NNNSRectsEqual(window.frame, haxFrame);
         // AX will return an empty string when CG returns nil/unset!
         BOOL namesMatch = (window.name.length == 0 && haxTitle.length == 0) || [window.name isEqualToString:haxTitle];
         

--- a/Switch/SWCoreWindowController.m
+++ b/Switch/SWCoreWindowController.m
@@ -75,7 +75,7 @@
 
 - (void)loadWindow;
 {
-    NSRect contentRect = self.screen.frame;
+    CGRect contentRect = self.screen.frame;
     NSWindow *switcherWindow = [[NSWindow alloc] initWithContentRect:contentRect styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO screen:self.screen];
     switcherWindow.movableByWindowBackground = NO;
     switcherWindow.hasShadow = NO;
@@ -84,7 +84,7 @@
     switcherWindow.level = NSPopUpMenuWindowLevel;
     self.window = switcherWindow;
     
-    NSRect displayRect = [switcherWindow convertRectFromScreen:contentRect];
+    CGRect displayRect = [switcherWindow convertRectFromScreen:contentRect];
     SWHUDCollectionView *collectionView = [[SWHUDCollectionView alloc] initWithFrame:displayRect];
     collectionView.dataSource = self;
     collectionView.delegate = self;
@@ -145,14 +145,14 @@
 
 - (NSView *)HUDCollectionView:(SWHUDCollectionView *)view viewForCellAtIndex:(NSUInteger)index;
 {
-    BailUnless([view isEqual:self.collectionView], [[NSView alloc] initWithFrame:NSZeroRect]);
+    BailUnless([view isEqual:self.collectionView], [[NSView alloc] initWithFrame:CGRectZero]);
     
     // Boundary method, index may not be in-bounds.
     SWWindowGroup *windowGroup = index < self.windowGroups.count ? self.windowGroups[index] : nil;
-    BailUnless(windowGroup, [[NSView alloc] initWithFrame:NSZeroRect]);
+    BailUnless(windowGroup, [[NSView alloc] initWithFrame:CGRectZero]);
 
     if (!self.collectionCells[windowGroup]) {
-        self.collectionCells[windowGroup] = [[SWWindowThumbnailView alloc] initWithFrame:NSZeroRect windowGroup:windowGroup];
+        self.collectionCells[windowGroup] = [[SWWindowThumbnailView alloc] initWithFrame:CGRectZero windowGroup:windowGroup];
     }
 
     return self.collectionCells[windowGroup];

--- a/Switch/SWCoreWindowService.m
+++ b/Switch/SWCoreWindowService.m
@@ -204,7 +204,7 @@ static int kScrollThreshold = 50;
             for (NSScreen *screen in screens) {
                 SWCoreWindowController *windowController = [[SWCoreWindowController alloc] initWithScreen:screen];
                 windowController.delegate = self;
-                windowControllers[[NSValue valueWithRect:[screen sw_absoluteFrame]]] = windowController;
+                windowControllers[[NSValue valueWithRect:screen.frame]] = windowController;
                 
                 // Force-update the window's frame on the correct screen—it gets incorrectly updated (by what?) between -loadWIndow and here.
                 [windowController.window setFrame:screen.frame display:YES];
@@ -315,12 +315,12 @@ static int kScrollThreshold = 50;
     }
     
     for (SWWindowGroup *windowGroup in self.windowGroups) {
-        CGRect unboxedScreenFrame = [[windowGroup screen] sw_absoluteFrame];
+        CGRect unboxedScreenFrame = [windowGroup screen].frame;
         NSValue *screenFrame = [NSValue valueWithRect:unboxedScreenFrame];
         
         // If there is no window controller that owns that screen, assign the group to the main screen.
         if (![windowsPerScreen objectForKey:screenFrame]) {
-            screenFrame = [NSValue valueWithRect:[[NSScreen mainScreen] sw_absoluteFrame]];
+            screenFrame = [NSValue valueWithRect:[NSScreen mainScreen].frame];
             Check([windowsPerScreen objectForKey:screenFrame]);
         }
         

--- a/Switch/SWHUDCollectionView.m
+++ b/Switch/SWHUDCollectionView.m
@@ -45,7 +45,7 @@
 
 #pragma mark Initialization
 
-- (id)initWithFrame:(NSRect)frame
+- (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (!self) {
@@ -53,8 +53,8 @@
     }
     
     _cells = [NSMutableArray new];
-    _hud = [[SWHUDView alloc] initWithFrame:NSZeroRect];
-    _selectionBox = [[SWSelectionBoxView alloc] initWithFrame:NSZeroRect];
+    _hud = [[SWHUDView alloc] initWithFrame:CGRectZero];
+    _selectionBox = [[SWSelectionBoxView alloc] initWithFrame:CGRectZero];
     _selectedIndex = NSNotFound;
 
     return self;
@@ -205,7 +205,7 @@
 {
     for (NSUInteger i = 0; i < self.numberOfCells; ++i) {
         NSPoint relativePoint = [self convertPoint:point toView:self.cells[i]];
-        NSRect cellFrame = CLASS_CAST(NSView, self.cells[i]).bounds;
+        CGRect cellFrame = CLASS_CAST(NSView, self.cells[i]).bounds;
         
         if (NSPointInRect(relativePoint, cellFrame)) {
             return i;

--- a/Switch/SWHUDView.m
+++ b/Switch/SWHUDView.m
@@ -19,7 +19,7 @@
 
 #pragma mark Initialization
 
-- (id)initWithFrame:(NSRect)frame
+- (id)initWithFrame:(CGRect)frame
 {
     if (!(self = [super initWithFrame:frame])) { return nil; }
 

--- a/Switch/SWLoggingService.m
+++ b/Switch/SWLoggingService.m
@@ -106,7 +106,7 @@
     
     for (NSDictionary *description in rawList) {
         CGWindowID windowID = (CGWindowID)[[description objectForKey:(__bridge NSString *)kCGWindowNumber] unsignedLongValue];
-        CGImageRef cgContents = NNCFAutorelease(CGWindowListCreateImage(CGRectZero, kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageBoundsIgnoreFraming));
+        CGImageRef cgContents = NNCFAutorelease(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageBoundsIgnoreFraming));
         
         if (!cgContents) {
             [handle writeData:[[NSString stringWithFormat:@"Failed to save window contents for window ID %u: CGWindowListCreateImage returned NULL\n", windowID] dataUsingEncoding:NSUTF8StringEncoding]];

--- a/Switch/SWLoggingService.m
+++ b/Switch/SWLoggingService.m
@@ -106,7 +106,7 @@
     
     for (NSDictionary *description in rawList) {
         CGWindowID windowID = (CGWindowID)[[description objectForKey:(__bridge NSString *)kCGWindowNumber] unsignedLongValue];
-        CGImageRef cgContents = NNCFAutorelease(CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageBoundsIgnoreFraming));
+        CGImageRef cgContents = NNCFAutorelease(CGWindowListCreateImage(CGRectZero, kCGWindowListOptionIncludingWindow, windowID, kCGWindowImageBoundsIgnoreFraming));
         
         if (!cgContents) {
             [handle writeData:[[NSString stringWithFormat:@"Failed to save window contents for window ID %u: CGWindowListCreateImage returned NULL\n", windowID] dataUsingEncoding:NSUTF8StringEncoding]];
@@ -120,7 +120,7 @@
         
         NSImage *contents = [[NSImage alloc] initWithCGImage:cgContents size:(NSSize){.width = CGImageGetWidth(cgContents), .height = CGImageGetHeight(cgContents)}];
         [contents lockFocus];
-        NSBitmapImageRep *bitmapContents = [[NSBitmapImageRep alloc] initWithFocusedViewRect:(NSRect){.origin = NSZeroPoint, .size = contents.size}];
+        NSBitmapImageRep *bitmapContents = [[NSBitmapImageRep alloc] initWithFocusedViewRect:(CGRect){.origin = NSZeroPoint, .size = contents.size}];
         [contents unlockFocus];
         NSData *pngContents = [bitmapContents representationUsingType:NSPNGFileType properties:nil];
         if (!pngContents) {

--- a/Switch/SWRoundedRectView.m
+++ b/Switch/SWRoundedRectView.m
@@ -19,7 +19,7 @@
 
 #pragma mark Initialization
 
-- (instancetype)initWithFrame:(NSRect)frameRect;
+- (instancetype)initWithFrame:(CGRect)frameRect;
 {
     if (!(self = [super initWithFrame:frameRect])) { return nil; }
     

--- a/Switch/SWSelectionBoxView.m
+++ b/Switch/SWSelectionBoxView.m
@@ -19,7 +19,7 @@
 
 #pragma mark Initialization
 
-- (id)initWithFrame:(NSRect)frame
+- (id)initWithFrame:(CGRect)frame
 {
     if (!(self = [super initWithFrame:frame])) { return nil; }
     

--- a/Switch/SWWindow.h
+++ b/Switch/SWWindow.h
@@ -28,8 +28,8 @@ typedef NSPoint NNVec2;
 @property (nonatomic, strong, readonly) SWApplication *application;
 @property (atomic, copy, readonly) NSDictionary *windowDescription;
 
-- (NSRect)frame;
-- (NSRect)flippedFrame;
+- (CGRect)frame;
+- (CGRect)flippedFrame;
 - (NSString *)name;
 - (NSScreen *)screen;
 - (CGWindowID)windowID;

--- a/Switch/SWWindow.h
+++ b/Switch/SWWindow.h
@@ -29,7 +29,7 @@ typedef NSPoint NNVec2;
 @property (atomic, copy, readonly) NSDictionary *windowDescription;
 
 - (NSRect)frame;
-- (CGRect)cartesianFrame;
+- (NSRect)flippedFrame;
 - (NSString *)name;
 - (NSScreen *)screen;
 - (CGWindowID)windowID;

--- a/Switch/SWWindow.m
+++ b/Switch/SWWindow.m
@@ -70,15 +70,15 @@
 
 #pragma mark SWWindow
 
-- (NSRect)flippedFrame;
+- (CGRect)flippedFrame;
 {
     CGRect result = {{},{}};
     bool success = CGRectMakeWithDictionaryRepresentation((__bridge CFDictionaryRef)[self.windowDescription objectForKey:(NSString *)kCGWindowBounds], &result);
-    BailUnless(success, ((NSRect){{0.0,0.0},{0.0,0.0}}));
+    BailUnless(success, ((CGRect){{0.0,0.0},{0.0,0.0}}));
     return result;
 }
 
-- (NSRect)frame;
+- (CGRect)frame;
 {
     CGFloat totalScreenHeight = NSScreen.sw_totalScreenHeight;
     CGRect flippedFrame = self.flippedFrame;
@@ -160,8 +160,8 @@
 
 - (NNVec2)offsetOfCenterToCenterOfWindow:(SWWindow *)window;
 {
-    NSRect selfBounds = self.frame;
-    NSRect windowBounds = window.frame;
+    CGRect selfBounds = self.frame;
+    CGRect windowBounds = window.frame;
     
     return (NNVec2){
         .x = ((windowBounds.origin.x + (windowBounds.size.width / 2.0)) - (selfBounds.origin.x + (selfBounds.size.width / 2.0))),
@@ -171,8 +171,8 @@
 
 - (NSSize)sizeDifferenceFromWindow:(SWWindow *)window;
 {
-    NSRect selfBounds = self.frame;
-    NSRect windowBounds = window.frame;
+    CGRect selfBounds = self.frame;
+    CGRect windowBounds = window.frame;
     
     return (NSSize){
         .width = selfBounds.size.width - windowBounds.size.width,

--- a/Switch/SWWindowGroup.m
+++ b/Switch/SWWindowGroup.m
@@ -81,7 +81,7 @@
     return self.mainWindow.name;
 }
 
-- (NSRect)frame;
+- (CGRect)frame;
 {
     NSPoint min = self.mainWindow.frame.origin;
     NSPoint max = min;
@@ -94,10 +94,10 @@
         max.y = MAX(max.y, frame.origin.y + frame.size.height);
     }
     
-    return (NSRect){.origin = min, .size.width = max.x - min.x, .size.height = max.y - min.y};
+    return (CGRect){.origin = min, .size.width = max.x - min.x, .size.height = max.y - min.y};
 }
 
-- (NSRect)flippedFrame;
+- (CGRect)flippedFrame;
 {
     NSPoint min = self.mainWindow.flippedFrame.origin;
     NSPoint max = min;
@@ -110,7 +110,7 @@
         max.y = MAX(max.y, flippedFrame.origin.y + flippedFrame.size.height);
     }
     
-    return (NSRect){.origin = min, .size.width = max.x - min.x, .size.height = max.y - min.y};
+    return (CGRect){.origin = min, .size.width = max.x - min.x, .size.height = max.y - min.y};
 }
 
 #pragma mark SWWindowGroup
@@ -151,16 +151,16 @@
              
              (lldb) po [((NSOrderedSet *)[windowGroupList[7] windows])[2] application]
              0x6080002268e0 <82769 (com.apple.appkit.xpc.openAndSavePanelService)>
-             (lldb) p (NSRect)[((NSOrderedSet *)[windowGroupList[7] windows])[2] frame]
-             (NSRect) $8 = (x=222, y=69), (width=489, height=319)
+             (lldb) p (CGRect)[((NSOrderedSet *)[windowGroupList[7] windows])[2] frame]
+             (CGRect) $8 = (x=222, y=69), (width=489, height=319)
 
              (lldb) po [((NSOrderedSet *)[windowGroupList[7] windows])[3] application]
              0x608000226560 <82763 (TextEdit)>
-             (lldb) p (NSRect)[((NSOrderedSet *)[windowGroupList[7] windows])[3] frame]
-             (NSRect) $7 = (x=222, y=69), (width=490, height=319)
+             (lldb) p (CGRect)[((NSOrderedSet *)[windowGroupList[7] windows])[3] frame]
+             (CGRect) $7 = (x=222, y=69), (width=490, height=319)
              
-             (lldb) p (NSRect)[((NSOrderedSet *)[windowGroupList[7] windows])[4] frame]
-             (NSRect) $9 = (x=147, y=47), (width=640, height=412)
+             (lldb) p (CGRect)[((NSOrderedSet *)[windowGroupList[7] windows])[4] frame]
+             (CGRect) $9 = (x=147, y=47), (width=640, height=412)
              
              */
             break;

--- a/Switch/SWWindowGroup.m
+++ b/Switch/SWWindowGroup.m
@@ -83,13 +83,31 @@
 
 - (NSRect)frame;
 {
-    NSPoint min = self.mainWindow.frame.origin, max = self.mainWindow.frame.origin;
+    NSPoint min = self.mainWindow.frame.origin;
+    NSPoint max = min;
     
     for (SWWindow *window in self.windows) {
-        min.x = MIN(min.x, window.frame.origin.x);
-        min.y = MIN(min.y, window.frame.origin.y);
-        max.x = MAX(max.x, window.frame.origin.x + window.frame.size.width);
-        max.y = MAX(max.y, window.frame.origin.y + window.frame.size.height);
+        CGRect frame = window.frame;
+        min.x = MIN(min.x, frame.origin.x);
+        min.y = MIN(min.y, frame.origin.y);
+        max.x = MAX(max.x, frame.origin.x + frame.size.width);
+        max.y = MAX(max.y, frame.origin.y + frame.size.height);
+    }
+    
+    return (NSRect){.origin = min, .size.width = max.x - min.x, .size.height = max.y - min.y};
+}
+
+- (NSRect)flippedFrame;
+{
+    NSPoint min = self.mainWindow.flippedFrame.origin;
+    NSPoint max = min;
+    
+    for (SWWindow *window in self.windows) {
+        CGRect flippedFrame = window.flippedFrame;
+        min.x = MIN(min.x, flippedFrame.origin.x);
+        min.y = MIN(min.y, flippedFrame.origin.y);
+        max.x = MAX(max.x, flippedFrame.origin.x + flippedFrame.size.width);
+        max.y = MAX(max.y, flippedFrame.origin.y + flippedFrame.size.height);
     }
     
     return (NSRect){.origin = min, .size.width = max.x - min.x, .size.height = max.y - min.y};

--- a/Switch/SWWindowThumbnailView.h
+++ b/Switch/SWWindowThumbnailView.h
@@ -20,7 +20,7 @@
 
 @interface SWWindowThumbnailView : NSView
 
-- (instancetype)initWithFrame:(NSRect)frameRect windowGroup:(SWWindowGroup *)window;
+- (instancetype)initWithFrame:(CGRect)frameRect windowGroup:(SWWindowGroup *)window;
 
 - (void)setActive:(BOOL)active;
 

--- a/Switch/SWWindowThumbnailView.m
+++ b/Switch/SWWindowThumbnailView.m
@@ -45,7 +45,7 @@
 
 #pragma mark Initialization
 
-- (id)initWithFrame:(NSRect)frame windowGroup:(SWWindowGroup *)windowGroup;
+- (id)initWithFrame:(CGRect)frame windowGroup:(SWWindowGroup *)windowGroup;
 {
     if (!(self = [super initWithFrame:frame])) { return nil; }
     
@@ -117,7 +117,7 @@
     self.thumbnailLayer.frame = self.bounds;
     
     NSSize thumbSize = self.thumbnailLayer.bounds.size;
-    NSRect windowGroupFrame = self.windowGroup.frame;
+    CGRect windowGroupFrame = self.windowGroup.frame;
     
     CGFloat scale = MIN(thumbSize.width / windowGroupFrame.size.width, thumbSize.height / windowGroupFrame.size.height);
     
@@ -127,7 +127,7 @@
     for (NSUInteger i = 0; i < self.windowGroup.windows.count; i++) {
         SWWindow *window = self.windowGroup.windows[i];
         CALayer *layer = [self _sublayerForWindow:window];
-        NSRect frame = window.frame;
+        CGRect frame = window.frame;
         
         // Move the frame's origin to be anchored at the "bottom left" of the windowFrame.
         frame.origin.x -= windowGroupFrame.origin.x;
@@ -267,7 +267,7 @@
 
 - (void)_updateIconLayout;
 {
-    NSRect thumbFrame = self.bounds;
+    CGRect thumbFrame = self.bounds;
     CGFloat thumbSize = thumbFrame.size.width;
 
     // imageSize is a lie, but it does give the correct aspect ratio. It's always been a square anecdotally, but you can't be too careful!
@@ -279,7 +279,7 @@
     // make the size fit correctly
     imageSize = NSMakeSize(MIN(round(imageSize.width * scale), iconSize), MIN(round(imageSize.height * scale), iconSize));
     
-    self.iconLayer.frame = (NSRect){
+    self.iconLayer.frame = (CGRect){
         .size = imageSize,
         .origin.x = thumbFrame.origin.x + (thumbFrame.size.width - imageSize.width),
         .origin.y = thumbFrame.origin.y

--- a/Switch/SWWindowThumbnailView.m
+++ b/Switch/SWWindowThumbnailView.m
@@ -117,7 +117,7 @@
     self.thumbnailLayer.frame = self.bounds;
     
     NSSize thumbSize = self.thumbnailLayer.bounds.size;
-    NSRect windowGroupFrame = self.windowGroup.cartesianFrame;
+    NSRect windowGroupFrame = self.windowGroup.frame;
     
     CGFloat scale = MIN(thumbSize.width / windowGroupFrame.size.width, thumbSize.height / windowGroupFrame.size.height);
     
@@ -127,7 +127,7 @@
     for (NSUInteger i = 0; i < self.windowGroup.windows.count; i++) {
         SWWindow *window = self.windowGroup.windows[i];
         CALayer *layer = [self _sublayerForWindow:window];
-        NSRect frame = window.cartesianFrame;
+        NSRect frame = window.frame;
         
         // Move the frame's origin to be anchored at the "bottom left" of the windowFrame.
         frame.origin.x -= windowGroupFrame.origin.x;

--- a/Switch/helpers.h
+++ b/Switch/helpers.h
@@ -17,7 +17,7 @@
 
 #define NNAssertMainQueue() NSAssert([[NSThread currentThread] isMainThread], @"Current path of execution must be run on the main thread");
 
-BOOL NNNSRectsEqual(NSRect a, NSRect b);
+BOOL NNCGRectsEqual(CGRect a, CGRect b);
 BOOL NNNSSizesEqual(NSSize a, NSSize b);
 
 void *NNCFAutorelease(CFTypeRef cfObject);

--- a/Switch/helpers.m
+++ b/Switch/helpers.m
@@ -20,7 +20,7 @@ BOOL NNNSSizesEqual(NSSize a, NSSize b)
     return a.width == b.width && a.height == b.height;
 }
 
-BOOL NNNSRectsEqual(NSRect a, NSRect b)
+BOOL NNCGRectsEqual(CGRect a, CGRect b)
 {
     return a.origin.x == b.origin.x && a.origin.y == b.origin.y && NNNSSizesEqual(a.size, b.size);
 }

--- a/Switch/imageComparators.h
+++ b/Switch/imageComparators.h
@@ -70,7 +70,7 @@ static BOOL (^imagesDifferByCachedTIFFComparison)(NSImage *, NSImage *) = ^(NSIm
 //            [NSGraphicsContext saveGraphicsState];
 //            [NSGraphicsContext setCurrentContext:[NSGraphicsContext graphicsContextWithGraphicsPort:result flipped:NO]];
 //            [[NSGraphicsContext currentContext] setImageInterpolation:NSImageInterpolationNone];
-//            [image drawInRect:NSMakeRect(0, 0, x, y) fromRect:NSZeroRect operation:NSCompositeCopy fraction:1.0];
+//            [image drawInRect:CGRectMake(0, 0, x, y) fromRect:CGRectZero operation:NSCompositeCopy fraction:1.0];
 //            [NSGraphicsContext restoreGraphicsState];
 //            objc_setAssociatedObject(image, bitmapContextKey, (__bridge id)result, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 //        }

--- a/SwitchTests/SWHUDCollectionViewTests.m
+++ b/SwitchTests/SWHUDCollectionViewTests.m
@@ -44,7 +44,7 @@
 
 /*- (void)testEmptyCollectionView
 {
-    NSRect windowRect = NSMakeRect(0.0, 0.0, 800.0, 100.0);
+    CGRect windowRect = CGRectMake(0.0, 0.0, 800.0, 100.0);
     NSWindow *window = [[NSWindow alloc] initWithContentRect:windowRect styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO];
     {
         window.movableByWindowBackground = NO;
@@ -55,7 +55,7 @@
         window.acceptsMouseMovedEvents = YES;
     }
     
-    NNHUDCollectionView *collectionView = [[NNHUDCollectionView alloc] initWithFrame:NSMakeRect((800.0 - 100.0) / 2.0, 0.0, 100.0, 100.0)];
+    NNHUDCollectionView *collectionView = [[NNHUDCollectionView alloc] initWithFrame:CGRectMake((800.0 - 100.0) / 2.0, 0.0, 100.0, 100.0)];
     [window.contentView addSubview:collectionView];
     
     [[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];


### PR DESCRIPTION
Also use `CGDisplayBounds` to establish on which screen a window resides, instead of horrible and fragile hacks attempting to get `NSScreen` frames and CG frames to conform to each others' coordinate spaces.

Fixes #89.
